### PR TITLE
fix translation about Japanese at language section - config.php

### DIFF
--- a/app/var/config/config.php
+++ b/app/var/config/config.php
@@ -185,7 +185,7 @@
         'es' => 'Español',
         'fa' => 'فارسی',
         'fr' => 'Français',
-        'ja' => '日本人',
+        'ja' => '日本語',
         'lt' => 'Lietuvos',
         'mk' => 'македонски',
         'nl' => 'Nederlands',


### PR DESCRIPTION
"人" means people.
"語" means language.
