### PR TITLE
Added ubuntu specific installation method to Download page

### DIFF
--- a/app/var/languages/en.php
+++ b/app/var/languages/en.php
@@ -90,6 +90,8 @@
         'download_windows'                => 'Windows DLLs',
         'download_developer_tools'        => 'Developer Tools',
         'download_ide_stubs'              => 'IDE stubs',
+        'download_ubuntu'                 => 'To install Phalcon on Ubuntu you need to follow these steps:',
+        'download_ubuntu_1'               => 'If you are missing apt-add-repository run the following command:',
         'download_note'                   => 'Phalcon is a C extension, so you need to download a binary for your platform or compile it from source code.',
         'download_compilation'            => 'Compilation',
         'download_compilation_1'          => 'On Linux you can easily compile and install the extension from source code.',

--- a/app/views/download/index.volt
+++ b/app/views/download/index.volt
@@ -16,6 +16,29 @@
 
     <div class="note">{{ tr('download_note') }}</div>
 
+
+    <h2>Ubuntu</h2>
+    <p>
+        {{ tr('download_ubuntu') }}
+    </p>
+    <div class="highlight1">
+<pre><code class="bash">sudo apt-add-repository ppa:phalcon/stable
+
+sudo apt-get update
+
+sudo apt-get install php5-phalcon</code></pre>
+    </div>
+
+    <p>
+        {{ tr('download_ubuntu_1') }}
+
+
+    <div class="highlight1">
+<pre><code class="bash">sudo apt-get-install python-software-properties</code></pre>
+    </div>
+
+    </p>
+
     <h2>{{ tr('download_compilation') }}</h2>
     <p>{{ tr('download_compilation_1') }}</p>
 


### PR DESCRIPTION
Instructions for Ubuntu added after me and Nikos made the launchpad PPA ready. I've tested the installation method.

PPA: https://launchpad.net/~phalcon/+archive/ubuntu/stable

This PPA is now the official PPA.
