### PR TITLE
Fixed a syntax error and a fatal error due to mistyping the method

### DIFF
--- a/app/controllers/IndexController.php
+++ b/app/controllers/IndexController.php
@@ -12,7 +12,7 @@ class IndexController extends \ControllerBase
 
     public function notFoundAction()
     {
-        $this->response->setResponseCode(404, 'Not Found'); sta
+        $this->response->setStatusCode(404, 'Not Found');
         $this->view->pick('404/404');
     }
 


### PR DESCRIPTION
The line was causing that to happen:

Fatal error: Call to undefined method Phalcon\Http\Response::setResponseCode() in /storage/htdocs/sites/phalconphp/app/controllers/IndexController.php on line 15

(see http://phalconphp.com/en/qqqqqq while the error is not fixed yet)
