### PR TITLE
Fixed apt-add-repository command

### DIFF
--- a/app/views/download/index.volt
+++ b/app/views/download/index.volt
@@ -8,24 +8,16 @@
 
             <div class="highlight1">
 
-                <pre>
-                    <code class="bash">
-sudo apt-add-repository ppa:phalcon/stable
+                <pre><code class="bash">sudo apt-add-repository ppa:phalcon/stable
 sudo apt-get update
-sudo apt-get install php5-phalcon
-                    </code>
-                </pre>
+sudo apt-get install php5-phalcon</code></pre>
             </div>
 
             <p>
             {{ tr('download_ubuntu_2') }}
             </p>
             <div class="highlight1">
-                <pre>
-                   <code class="bash">
-sudo apt-add-repository ppa:phalcon/legacy
-                   </code>
-                </pre>
+                <pre><code class="bash">sudo apt-add-repository ppa:phalcon/legacy</code></pre>
             </div>
 
 
@@ -33,11 +25,7 @@ sudo apt-add-repository ppa:phalcon/legacy
                 {{ tr('download_ubuntu_1') }}
 
                 <div class="highlight1">
-                    <pre>
-                        <code class="bash">
-sudo apt-get install python-software-properties
-                        </code>
-                    </pre>
+                    <pre><code class="bash">sudo apt-get install python-software-properties</code></pre>
                 </div>
             </p>
 
@@ -56,9 +44,7 @@ sudo apt-get install python-software-properties
 
             <p>
                 <div class="highlight1">
-                    <pre>
-                        <code class="bash">
-#Ubuntu
+                    <pre><code class="bash">#Ubuntu
     sudo apt-get install php5-dev php5-mysql gcc libpcre3-dev
 
 #Fedora
@@ -74,9 +60,7 @@ sudo apt-get install python-software-properties
     brew tap homebrew/dupes
     brew tap homebrew/versions
     brew tap homebrew/php
-    brew install php5x php5x-phalcon # Where "x" - minor number of PHP
-                        </code>
-                    </pre>
+    brew install php5x php5x-phalcon # Where "x" - minor number of PHP</code></pre>
                 </div>
             </p>
 
@@ -86,13 +70,9 @@ sudo apt-get install python-software-properties
             <p>{{ tr('download_compilation_11') }}</p>
 
             <p>
-                <pre>
-                    <code class="bash">
-git clone --depth=1 git://github.com/phalcon/cphalcon.git
+                <pre><code class="bash">git clone --depth=1 git://github.com/phalcon/cphalcon.git
 cd cphalcon/build
-sudo ./install
-                    </code>
-                </pre>
+sudo ./install</code></pre>
             </p>
 
             <p>{{ tr('download_compilation_12') }}</p>

--- a/app/views/download/index.volt
+++ b/app/views/download/index.volt
@@ -25,7 +25,11 @@ sudo apt-get install php5-phalcon</code></pre>
                 {{ tr('download_ubuntu_1') }}
 
                 <div class="highlight1">
-                    <pre><code class="bash">sudo apt-get install python-software-properties</code></pre>
+                    <pre><code class="bash"># Ubuntu 14.04+
+sudo apt-get install software-properties-common
+
+# Ubuntu 12.04
+sudo apt-get install python-software-properties</code></pre>
                 </div>
             </p>
 

--- a/app/views/download/vagrant.volt
+++ b/app/views/download/vagrant.volt
@@ -19,10 +19,8 @@
     <li>{{ tr('download_box_doc_root', '/var/www') }}</li>
 </ul>
 
-<pre style="margin:0px">
-    <code>vagrant init phalconbox53 https://s3-eu-west-1.amazonaws.com/phalcon/phalcon125-apache2-php53-mysql55.box
-vagrant up</code>
-</pre>
+<pre style="margin:0px"><code>vagrant init phalconbox53 https://s3-eu-west-1.amazonaws.com/phalcon/phalcon125-apache2-php53-mysql55.box
+vagrant up</code></pre>
 
 <h3>{{ tr('download_box_2') }}</h3>
 
@@ -39,18 +37,14 @@ vagrant up</code>
     <li>{{ tr('download_box_doc_root', '/var/www') }}</li>
 </ul>
 
-<pre style="margin:0px">
-    <code>vagrant init phalconbox https://s3-eu-west-1.amazonaws.com/phalcon/phalcon125-apache2-php54-mysql55.box
-vagrant up</code>
-</pre>
+<pre style="margin:0px"><code>vagrant init phalconbox https://s3-eu-west-1.amazonaws.com/phalcon/phalcon125-apache2-php54-mysql55.box
+vagrant up</code></pre>
 
 <h3>{{ tr('download_examples') }}</h3>
 <p>{{ tr('download_examples_1') }}</p>
 
-<pre style="margin:0px">
-<code>http://&lt;vagrant-box-ip&gt;/website
-http://&lt;vagrant-box-ip&gt;/invo</code>
-</pre>
+<pre style="margin:0px"><code>http://&lt;vagrant-box-ip&gt;/website
+http://&lt;vagrant-box-ip&gt;/invo</code></pre>
 
 </div>
 </div>

--- a/public/html/api.html
+++ b/public/html/api.html
@@ -232,9 +232,7 @@
 
                     <p>
                     <div class="highlight">
-                        <pre>
-    public __construct ($frontend, $options = null )
-                        </pre>
+                        <pre>public __construct ($frontend, $options = null )</pre>
                     </div>
                     </p>
 
@@ -264,9 +262,7 @@
 
                     <p>
                     <div class="highlight">
-                        <pre>
-    public __construct ($frontend, $options = null )
-                        </pre>
+                        <pre>public __construct ($frontend, $options = null )</pre>
                     </div>
                     </p>
 

--- a/public/html/documentation.html
+++ b/public/html/documentation.html
@@ -160,7 +160,7 @@
                     <h2>Checking your installation</h2>
                     <p>We’ll assume you have Phalcon installed already. Check your phpinfo() output for a section referencing “Phalcon” or execute the code snippet below:</p>
                     <div class="highlight">
-                        <pre> print_r(get_loaded_extensions());</pre>
+                        <pre>print_r(get_loaded_extensions());</pre>
                     </div>
                     <p>The Phalcon extension should appear as part of the output:</p>
                     <div class="highlight">

--- a/public/html/downloads.html
+++ b/public/html/downloads.html
@@ -64,13 +64,11 @@
 
         <p>
         <div class="highlight">
-            <pre>
-#Ubuntu
+            <pre>#Ubuntu
 sudo apt-get install php5-dev php5-mysql gcc
 
 #Suse
-yast2 -i php5-pear php5-devel php5-mysql gcc
-            </pre>
+yast2 -i php5-pear php5-devel php5-mysql gcc</pre>
         </div>
         </p>
 
@@ -81,13 +79,11 @@ yast2 -i php5-pear php5-devel php5-mysql gcc
 
         <p>
         <div class="highlight">
-            <pre>
-git clone git://github.com/phalcon/cphalcon.git
+            <pre>git clone git://github.com/phalcon/cphalcon.git
 
 cd cphalcon/build
 
-sudo ./install
-            </pre>
+sudo ./install</pre>
         </div>
         </p>
 
@@ -95,9 +91,7 @@ sudo ./install
 
         <p>
         <div class="highlight">
-            <pre>
-extension=phalcon.so
-            </pre>
+            <pre>extension=phalcon.so</pre>
         </div>
         </p>
 
@@ -113,9 +107,7 @@ extension=phalcon.so
 
         <p>
         <div class="highlight">
-            <pre>
-# pkg_add -r phalcon
-            </pre>
+            <pre># pkg_add -r phalcon</pre>
         </div>
         </p>
 
@@ -123,9 +115,7 @@ extension=phalcon.so
 
         <p>
         <div class="highlight">
-            <pre>
-# cd /usr/ports/www/phalcon && make install clean
-            </pre>
+            <pre># cd /usr/ports/www/phalcon && make install clean</pre>
         </div>
         </p>
 


### PR DESCRIPTION
See phalcon/docs#531 and http://askubuntu.com/a/38035

Currently, 12.04, 14.04, 14.10 and 15.04 are supported (https://wiki.ubuntu.com/Releases) so only 12.04 needs the old command.