### PR TITLE
Add language to docs url from phalcon.link

### DIFF
--- a/app/views/index/index.volt
+++ b/app/views/index/index.volt
@@ -34,7 +34,7 @@
 
                     <p>
                         {{ locale.translate('header_slogan') }}
-                        <a id="bench-link" href="https://phalcon.link/docs" target="_blank">
+                        <a id="bench-link" href="https://phalcon.link/docs/{{language}}" target="_blank">
                             {{ locale.translate('see_for_yourself') }}
                         </a>
                     </p>

--- a/app/views/pages/support.volt
+++ b/app/views/pages/support.volt
@@ -15,7 +15,7 @@
                 <h3>{{ locale.translate('documentation') }}</h3>
             </div>
             <div class="col-lg-12">
-                <p>{{ locale.translate('support_documentation_1', link_to('https://phalcon.link/docs', locale.translate('documentation'), false)) }}</p>
+                <p>{{ locale.translate('support_documentation_1', link_to(url('https://phalcon.link/docs/' ~ language), locale.translate('documentation'), false)) }}</p>
             </div>
         </div>
         <div class="row">

--- a/app/views/partials/topmenu.volt
+++ b/app/views/partials/topmenu.volt
@@ -6,7 +6,7 @@
         </a>
     </li>
     <li>
-        <a href="https://phalcon.link/docs" class="header-nav-link" target="_blank">
+        <a href="https://phalcon.link/docs/{{language}}" class="header-nav-link" target="_blank">
             {{ locale.translate('docs') }}
         </a>
     </li>


### PR DESCRIPTION
###### Closes https://github.com/phalcon/docs/issues/1003

#### What am I?
Updated links to docs to include language.

When https://github.com/phalcon/link/pull/12 is implemented the URLs will link to the correct language but this PR is **NOT** blocked by the merge of https://github.com/phalcon/link/pull/12

