### PR TITLE
HTTP -> HTTPS. Stubs video guide frame

### DIFF
--- a/app/views/download/stubs.volt
+++ b/app/views/download/stubs.volt
@@ -12,7 +12,7 @@
         <h2>{{ locale.translate('download_ide_stubs') }}</h2>
         <p>{{ locale.translate('download_ide_stubs_1') }}</p>
         <div align="center">
-            <iframe src="http://player.vimeo.com/video/43455647" width="960" height="443" frameborder="0" webkitallowfullscreen="" mozallowfullscreen="" allowfullscreen=""></iframe>
+            <iframe src="https://player.vimeo.com/video/43455647" width="960" height="443" frameborder="0" webkitallowfullscreen="" mozallowfullscreen="" allowfullscreen=""></iframe>
         </div>
     </div>
 </section>


### PR DESCRIPTION
The website now provided by https scheme, but the video is under http.