### PR TITLE
Fixes links for Xampp and Wamp on Windows download page

### DIFF
--- a/app/views/download/windows.volt
+++ b/app/views/download/windows.volt
@@ -31,12 +31,12 @@
         <p>
         <ul class="dash-list">
             <li>
-                <a href="{{ utils.getDocsUrl(language) ~ '/webserver-xamp' }}">
+                <a href="{{ utils.getDocsUrl(language) ~ '/webserver-xampp' }}">
                     {{ locale.translate('download_windows_guides_xampp') }}
                 </a>
             </li>
             <li>
-                <a href="{{ utils.getDocsUrl(language) ~ '/webserver-wampp' }}">
+                <a href="{{ utils.getDocsUrl(language) ~ '/webserver-wamp' }}">
                     {{ locale.translate('download_windows_guides_wamp') }}
                 </a>
             </li>


### PR DESCRIPTION

The links to Xampp and Wamp redirect to a 404 page.
- `XAMPP` was missing the extra `p` 
- `WAMP` had an extra `p`

![xampp](https://user-images.githubusercontent.com/13909325/36669880-6a265b50-1ac4-11e8-9a0a-fe6eb4648d7e.PNG)

![wamp](https://user-images.githubusercontent.com/13909325/36669892-784b302a-1ac4-11e8-8427-8a1abedd8f7c.PNG)
