### PR TITLE
removing texts from home bg-slideshow

### DIFF
--- a/app/views/index/index.volt
+++ b/app/views/index/index.volt
@@ -7,12 +7,12 @@
     ============================== -->
 
     <ul class="bg-slideshow">
-        <li><span>Image 01</span></li>
-        <li><span>Image 02</span></li>
-        <li><span>Image 03</span></li>
-        <li><span>Image 04</span></li>
-        <li><span>Image 05</span></li>
-        <li><span>Image 06</span></li>
+        <li><span></span></li>
+        <li><span></span></li>
+        <li><span></span></li>
+        <li><span></span></li>
+        <li><span></span></li>
+        <li><span></span></li>
     </ul>
 
     <!-- =========================


### PR DESCRIPTION
At the top-left corner of the home page slideshow, there are texts like image 01 , image 02,...etc i've just deleted these texts  
<img width="469" alt="capture d ecran 2018-04-12 a 3 31 50 pm" src="https://user-images.githubusercontent.com/5613412/38684743-44a067aa-3e68-11e8-80ce-edafd6a4b053.png">
