### PR TITLE
Fixed language icons

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -104,7 +104,7 @@ return [
         ],
     ],
     'languages'     => [
-        'ar' => 'Armenian',
+        'ar' => 'Arabic',
         'bg' => 'Bulgarian',
         'ca' => 'Catalan',
         'cs' => 'Český',
@@ -142,6 +142,10 @@ return [
     'languages_map' => [
         'sv' => 'se',
         'vi' => 'vn',
+        'uk' => 'ua',
+        'hy' => 'am',
+        'da' => 'dk',
+        'kk' => 'kz',
     ],
     'doc_languages' => [
         'en',


### PR DESCRIPTION
Fixed Danish icon
Fixed Armenianicon
Fixed Kazakh icon
Fixed Ukraine icon

Renamed first Armenian to Arabic because of language code. Plus we have 2 Armenian in list.