### PR TITLE
Fedora download documentation update

### DIFF
--- a/app/views/download/linux.volt
+++ b/app/views/download/linux.volt
@@ -57,7 +57,7 @@ sudo apt-get install python-software-properties</code></pre>
 sudo apt-get install php5-dev php5-mysql gcc libpcre3-dev
 
 # Fedora
-sudo yum install php-devel php-mysqlnd gcc libtool pcre-devel
+sudo dnf install php-devel php-mysqlnd gcc libtool pcre-devel re2c
 
 # RHEL
 sudo yum install php-devel php-mysql gcc libtool pcre-devel


### PR DESCRIPTION
Dnf was introduced on Fedora 18 and switched as default package manager from Fedora 22 version. So it means yum is not used almost 4 years.